### PR TITLE
Add test pattern to loader config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ module.exports = {
     rules: [
       // other loaders here, this has to be the last one
       {
+        test: [/\.json$/, /\.js$/, /\.jx$/, /\.ts$/, /\.tsx$/, /\.css$/, /\.scss$/],
         loader: WebpackEnhancedStatsPlugin.loader
       }
     ]


### PR DESCRIPTION
Without this many regular configs just break. We only care about
(J|T)SX?, JSONs and (S)?CSS files. Images might be inlined as well
but they don't have original source.

Upgrade dependencies by the way.